### PR TITLE
perf(context): set logGroupNamePrefix for describeLogGroups

### DIFF
--- a/packages/cloudwatch-logs-auto-subscribe/functions/lib/cloudwatch-logs.js
+++ b/packages/cloudwatch-logs-auto-subscribe/functions/lib/cloudwatch-logs.js
@@ -1,7 +1,7 @@
 const AWS = require("./aws");
 const cloudWatchLogs = new AWS.CloudWatchLogs();
 
-const { DESTINATION_ARN, FILTER_NAME, FILTER_PATTERN, ROLE_ARN } = process.env;
+const { PREFIX, DESTINATION_ARN, FILTER_NAME, FILTER_PATTERN, ROLE_ARN } = process.env;
 const isLambda = DESTINATION_ARN.startsWith("arn:aws:lambda");
 const filterName = FILTER_NAME || "ship-logs";
 const filterPattern = FILTER_PATTERN || "";
@@ -47,7 +47,8 @@ const putSubscriptionFilter = async (logGroupName) => {
 const getLogGroups = async () => {
 	const loop = async (nextToken, acc = []) => {
 		const req = {
-			nextToken: nextToken
+			nextToken: nextToken,
+			logGroupNamePrefix: PREFIX
 		};
     
 		try {


### PR DESCRIPTION
Set logGroupNamePrefix with PREFIX environment parameter for describeLogGroups operation. So we that we will not get log groups which do not match the prefix from Cloudwatch.