### PR TITLE
increased timeout from 6 to 900 sec for new log groups

### DIFF
--- a/packages/cloudwatch-logs-auto-subscribe/template.yml
+++ b/packages/cloudwatch-logs-auto-subscribe/template.yml
@@ -42,7 +42,7 @@ Resources:
     Properties:
       Handler: functions/subscribe.newLogGroups
       Description: Subscribes a newly create CloudWatch log group to the specified ARN
-      Timeout: 6
+      Timeout: 900
       Policies:
         - Statement:
             Effect: Allow


### PR DESCRIPTION
Increased timeout on template.yaml for new log groups